### PR TITLE
Fix Firestore collection typo in approveTeamRequest

### DIFF
--- a/functions/src/firestore/request/approveTeamRequest.ts
+++ b/functions/src/firestore/request/approveTeamRequest.ts
@@ -22,7 +22,7 @@ export async function approveTeamRequest(event: FirestoreEvent<Change<QueryDocum
 
   const {requestId, teamId} = event.params;
 
-  const requestRef = await db.collection('teamId').doc(teamId).collection('requests').doc(requestId).get();
+  const requestRef = await db.collection('teams').doc(teamId).collection('requests').doc(requestId).get();
   const userProfileRef = await db.collection('userProfile').doc(requestId).get();
   const teamRef = await db.collection('teams').doc(teamId).get();
 


### PR DESCRIPTION
## Summary

Fixes a typo in `functions/src/firestore/request/approveTeamRequest.ts`: the request document lookup used `db.collection('teamId')` instead of `db.collection('teams')`.

```diff
- const requestRef = await db.collection('teamId').doc(teamId).collection('requests').doc(requestId).get();
+ const requestRef = await db.collection('teams').doc(teamId).collection('requests').doc(requestId).get();
```

Because of the typo, `requestRef` pointed at a non-existent `teamId` collection and never resolved to the actual team request document. All sibling functions (`createTeamRequest`, `deleteTeamRequest`) consistently use `db.collection('teams')` for this path.

## Verification

- `npm run build` (tsc) compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uP7Sj6JSnq69Qsv6Rems9

---
_Generated by [Claude Code](https://claude.ai/code/session_011uP7Sj6JSnq69Qsv6Rems9)_