### PR TITLE
Upgrade Functions runtime from Node.js 20 to Node.js 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Config Node Version
         uses: actions/setup-node@master
         with:
-          node-version: 20        
+          node-version: 22
       # Runs a single command using the runners shell
       # And of course we need to goto our functions folder to deploy
       - name: Install npm packages

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,7 @@
   },
   "type": "module",
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary

Cloud Functions deprecated the Node.js 20 runtime on 2026-04-30 and will decommission it on **2026-10-31**, after which deploys would fail (the warning already appears in every deploy log). This PR moves the Functions runtime to Node.js 22:

- `functions/package.json`: `engines.node` `"20"` → `"22"` — Firebase derives the deployed runtime (`nodejs22`) from this field.
- `.github/workflows/main.yml`: `node-version: 20` → `22` so CI installs dependencies with the same major version.

No code changes required — `@types/node` is already at `^22.x`.

## Verification

Under Node v22.22.2:
- `npm ci` installs cleanly
- `npm run build` (tsc) compiles without errors
- `npm run lint` passes
- Smoke test: the compiled `lib/index.js` loads successfully with all 63 function exports

The first deploy after merging will switch the runtime to `nodejs22` (the deploy action's firebase-tools 13.30.0 supports it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uP7Sj6JSnq69Qsv6Rems9

---
_Generated by [Claude Code](https://claude.ai/code/session_011uP7Sj6JSnq69Qsv6Rems9)_